### PR TITLE
Fix plugin for IntelliJ 2021.2+

### DIFF
--- a/src/main/java/com/github/anonfunc/vcidea/VoicecodePlugin.java
+++ b/src/main/java/com/github/anonfunc/vcidea/VoicecodePlugin.java
@@ -32,7 +32,6 @@ public class VoicecodePlugin implements ApplicationComponent, HttpHandler {
     public static final int DEFAULT_PORT = 8652;
 
     private static final Map<String, Integer> PLATFORM_TO_PORT = new HashMap<>();
-    public static final String EDITOR_SKIP_COPY_AND_CUT_FOR_EMPTY_SELECTION = "editor.skip.copy.and.cut.for.empty.selection";
     private Path pathToNonce;
 
     static {
@@ -84,12 +83,6 @@ public class VoicecodePlugin implements ApplicationComponent, HttpHandler {
         server.createContext("/" + nonce, this);
         server.setExecutor(null); // creates a default executor
         server.start();
-        RegistryValue registryValue = Registry.get(EDITOR_SKIP_COPY_AND_CUT_FOR_EMPTY_SELECTION);
-        if (!registryValue.asBoolean()) {
-            registryValue.setValue(true);
-        }
-
-
     }
 
     @Override


### PR DESCRIPTION
Fixes #8.

The plugin attempts to set the `editor.skip.copy.and.cut.for.empty.selection` registry setting, but this has been [removed in IntelliJ 2021.2+](https://stackoverflow.com/a/32907749/303833). Trying to set it generates a startup exception, and the plugin can't be used.

I'm not sure why we need to set this registry setting, so I've defaulted to removing it; we can suggest that users change it themselves (it was replaced with an [advanced setting](https://stackoverflow.com/a/32907749/303833)) themselves if it's necessary for the functioning of the plugin.

