### PR TITLE
Fix tool window actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     // Java support
     id("java")
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.3.0"
+    id("org.jetbrains.intellij") version "1.11.0"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "1.3.1"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@
 pluginGroup = com.github.anonfunc.vcidea
 pluginName = Voice Code IDEA
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.14
+pluginVersion = 0.0.15
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 203
-pluginUntilBuild = 222.*
+pluginUntilBuild = 223.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2022.2
+platformVersion = 2022.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/java/com/github/anonfunc/vcidea/commands/GivenActionCommand.java
+++ b/src/main/java/com/github/anonfunc/vcidea/commands/GivenActionCommand.java
@@ -3,8 +3,9 @@ package com.github.anonfunc.vcidea.commands;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.ui.playback.commands.ActionCommand;
+import com.intellij.openapi.wm.ToolWindow;
+
 import java.awt.Component;
 import java.awt.event.InputEvent;
 
@@ -21,7 +22,7 @@ public class GivenActionCommand implements VcCommand {
         ApplicationManager.getApplication().invokeAndWait(() -> {
             AnAction action = ActionManager.getInstance().getAction(actionId);
             InputEvent event = ActionCommand.getInputEvent(actionId);
-            final Editor e = VcCommand.getEditor();
+            final ToolWindow e = VcCommand.getToolWindow();
             Component component = null;
             if (e != null) {
                 component = e.getComponent();

--- a/src/main/java/com/github/anonfunc/vcidea/commands/VcCommand.java
+++ b/src/main/java/com/github/anonfunc/vcidea/commands/VcCommand.java
@@ -71,7 +71,8 @@ public interface VcCommand {
     static ToolWindow getToolWindow() {
         Project currentProject = getProject();
         ToolWindowManager twm = ToolWindowManager.getInstance(currentProject);
-        ToolWindow tw = twm.getToolWindow(twm.getActiveToolWindowId());        if (tw == null) {
+        ToolWindow tw = twm.getToolWindow(twm.getActiveToolWindowId());
+        if (tw == null) {
             System.out.println("No selected tool window?");
         }
         return tw;

--- a/src/main/java/com/github/anonfunc/vcidea/commands/VcCommand.java
+++ b/src/main/java/com/github/anonfunc/vcidea/commands/VcCommand.java
@@ -4,6 +4,8 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.IdeFocusManager;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import java.io.UnsupportedEncodingException;
@@ -64,6 +66,15 @@ public interface VcCommand {
             System.out.println("No selected editor?");
         }
         return e;
+    }
+
+    static ToolWindow getToolWindow() {
+        Project currentProject = getProject();
+        ToolWindowManager twm = ToolWindowManager.getInstance(currentProject);
+        ToolWindow tw = twm.getToolWindow(twm.getActiveToolWindowId());        if (tw == null) {
+            System.out.println("No selected tool window?");
+        }
+        return tw;
     }
 
     static PsiFile getPsiFile() {


### PR DESCRIPTION
Using this plugin with Talon and [Knausj's scripts](https://github.com/knausj85/knausj_talon), I noticed that actions like "TabNext" were not working when the terminal was focused. Digging a little deeper, it seems like actions could in general only be executed when the editor was selected.

This PR should fix this by using the component of the currently selected ToolWindow instead of the editor when trying to execute an action. When the focus is on the editor, everything works as previously.

And while I was at it, I also bumped the version to support 2022.3.