### PR TITLE
Fix release.yml base branch name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,5 +83,5 @@ jobs:
           gh pr create \
             --title "Changelog update - \`$VERSION\`" \
             --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version." \
-            --base main \
+            --base master \
             --head $BRANCH


### PR DESCRIPTION
It tries to create a PR to the branch ´main´, which doesn't exist