### PR TITLE
Bump the JDK used with releases to 17 so that it matches that used in the project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java 17 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: gradle
 
       # Set environment variables


### PR DESCRIPTION
I noticed that the release action failed for 0.0.16 (The change that I introduced). I believe that this is due to JDK 11 being used for release versus 17. This change bumps that version, although it is important to note that I am not able to test it fully myself (at least to my knowledge) due to my inability to publish... In any case, I felt obligated to submit this as it is in a bad state with regards to releasing.

Link to the failed action: https://github.com/anonfunc/intellij-voicecode/actions/runs/4875211163/jobs/8697120474#step:6:30